### PR TITLE
Fix util imports in main application

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,13 @@
 import os, mimetypes, subprocess
-from fastapi import FastAPI, Request, Response, HTTPException, Form
-from fastapi.responses import HTMLResponse, FileResponse, StreamingResponse, RedirectResponse, PlainTextResponse
+from fastapi import FastAPI, Request, Response, HTTPException, Form, BackgroundTasks
+from fastapi.responses import (
+    HTMLResponse,
+    FileResponse,
+    StreamingResponse,
+    RedirectResponse,
+    PlainTextResponse,
+    JSONResponse,
+)
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from sqlmodel import select, delete
@@ -16,9 +23,15 @@ from .utils import (
     cached_mp4_path_for,
     candidate_dir_for,
     ensure_hls,
-    generate_thumb_candidates
+    generate_thumb_candidates,
+    zip_cache_dir_for,
+    hls_dir_for,
+    hls_master_path,
+    is_directplay_mp4,
+    thumb_from_bytes,
+    perf_image_path,
+    download_file,
 )
-    zip_cache_dir_for, hls_dir_for, hls_master_path, is_directplay_mp4, thumb_from_bytes
 
 
 


### PR DESCRIPTION
## Summary
- add missing BackgroundTasks and JSONResponse imports
- bring in perf_image_path and download_file helpers from utils

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689720d5a634832fa7eafec9cbcca9f8